### PR TITLE
Stability and memory consumption improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM ruby:3.0.0
 
+RUN apt-get update && apt-get install -y libjemalloc2
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+EXPOSE 3000
+
 WORKDIR /myapp
 
 COPY . /myapp
 
-RUN apt-get update && apt-get install -y libjemalloc2
 RUN bundle install
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 RUN mkdir -p /tmp/imports
 
 ENTRYPOINT ["entrypoint.sh"]
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-EXPOSE 3000
-
 
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,14 @@ WORKDIR /myapp
 
 COPY . /myapp
 
+RUN apt-get update && apt-get install -y libjemalloc2
 RUN bundle install
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 RUN mkdir -p /tmp/imports
+
 ENTRYPOINT ["entrypoint.sh"]
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 EXPOSE 3000
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.0"
+ruby "3.0.0"
 
 gem 'activerecord-copy'
 gem 'sidekiq'

--- a/app/controllers/graph_protocol/tests_controller.rb
+++ b/app/controllers/graph_protocol/tests_controller.rb
@@ -103,6 +103,7 @@ class GraphProtocol::TestsController < ApplicationController
     params.require(:test).permit(:query_set_id,
                                  :speed_factor,
                                  :loop_queries,
+                                 :chunk_size,
                                  :query_limit,
                                  :environment_id,
                                  subgraphs: [])

--- a/app/jobs/graph_protocol/qlog_query_runner_job.rb
+++ b/app/jobs/graph_protocol/qlog_query_runner_job.rb
@@ -1,6 +1,6 @@
 class GraphProtocol::QlogQueryRunnerJob < ApplicationJob
   queue_as :default
-  sidekiq_options retry: false
+  sidekiq_options retry: 0, dead: false 
 
   def perform(test_instance_id, offset, limit)
     processor = GraphProtocol::Util::Qlog::RequestProcessor.new(test_instance_id,

--- a/app/jobs/graph_protocol/test_instance_master_job.rb
+++ b/app/jobs/graph_protocol/test_instance_master_job.rb
@@ -1,5 +1,5 @@
 class GraphProtocol::TestInstanceMasterJob < ApplicationJob
-  queue_as :default
+  queue_as :testmaster
   sidekiq_options retry: 2, dead: false
 
   def perform(id:)

--- a/app/models/graph_protocol/test.rb
+++ b/app/models/graph_protocol/test.rb
@@ -31,7 +31,7 @@ class GraphProtocol::Test < ApplicationRecord
 
   def set_default_values
     self.subgraphs = [] if self.subgraphs.nil?
-    self.chunk_size = 1000 if self.chunk_size.blank?
+    self.chunk_size = 100 if self.chunk_size.blank?
     self.sleep_enabled = true if self.sleep_enabled.nil?
     self.speed_factor = 1.0 if self.speed_factor.nil?
     self.loop_queries = false if self.loop_queries.nil?

--- a/app/models/graph_protocol/test.rb
+++ b/app/models/graph_protocol/test.rb
@@ -31,7 +31,7 @@ class GraphProtocol::Test < ApplicationRecord
 
   def set_default_values
     self.subgraphs = [] if self.subgraphs.nil?
-    self.chunk_size = 100 if self.chunk_size.blank?
+    self.chunk_size = 100 if self.chunk_size.nil?
     self.sleep_enabled = true if self.sleep_enabled.nil?
     self.speed_factor = 1.0 if self.speed_factor.nil?
     self.loop_queries = false if self.loop_queries.nil?

--- a/app/models/graph_protocol/test/instance.rb
+++ b/app/models/graph_protocol/test/instance.rb
@@ -91,6 +91,10 @@ class GraphProtocol::Test::Instance < ApplicationRecord
     update_attribute(:master_job,jid)
   end
 
+  def set_start_time(start_time)
+    update_attribute(:start_time, start_time)
+  end
+
   def run
     GraphProtocol::TestInstanceMasterJob.perform_later(id: self.id)
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,2 @@
 ---
-:concurrency: 50 
+:concurrency: 20 

--- a/db/migrate/20230213162230_remove_default_chunk_size.rb
+++ b/db/migrate/20230213162230_remove_default_chunk_size.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultChunkSize < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :graph_protocol_tests, :chunk_size, nil
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,22 @@ services:
       placement:
         constraints: [node.role == manager]
 
+  sidekiq-testmaster:
+    image: crypt1d/graphprotocol-qts
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+    networks:
+      - graphqts
+    depends_on:
+      - cache
+      - postgres
+      - web
+    command: bundle exec sidekiq -q testmaster 
+    env_file:
+      - .env
+    stop_grace_period: 60s
+
   sidekiq-imports:
     image: crypt1d/graphprotocol-qts
     deploy:

--- a/lib/graph_protocol/util/qlog/helpers.rb
+++ b/lib/graph_protocol/util/qlog/helpers.rb
@@ -14,7 +14,7 @@ module GraphProtocol
         end
 
         def sleep_until_ready(query, sleep_enabled, start_time, speed_factor = 1.0)
-          offset = get_remaining_offset(query[:offset], start_time) / speed_factor
+          offset = get_remaining_offset(query.offset, start_time, speed_factor)
           if sleep_enabled
             while offset > 1
               sleep 1
@@ -26,8 +26,8 @@ module GraphProtocol
 
         end
 
-        def get_remaining_offset(query_offset = 0.0, start_time)
-          remain = query_offset - (current_time - start_time)
+        def get_remaining_offset(query_offset = 0.0, start_time, speed_factor)
+          remain = (query_offset / speed_factor) - (current_time - start_time)
           remain > 0 ? remain : 0.0
         end
 

--- a/lib/graph_protocol/util/qlog/request_processor.rb
+++ b/lib/graph_protocol/util/qlog/request_processor.rb
@@ -30,14 +30,16 @@ module GraphProtocol
               barrier.async do
                 task.with_timeout(30) do
                   result = internet.post(*build_request(query))
+                  # puts result.read
+                  #unless result.success?
+                  #  puts "Failed query: #{query[:query_id]}"
+                  #  puts "#{result.inspect}"
+                  #end
+                  #
+                  result.close
                 end
               end
 
-              #unless result.success?
-              #  puts "Failed query: #{query[:query_id]}"
-              #  puts "#{result.inspect}"
-              #end
-              
               break if cancelled?
             end
 

--- a/lib/graph_protocol/util/qlog/request_processor.rb
+++ b/lib/graph_protocol/util/qlog/request_processor.rb
@@ -23,7 +23,7 @@ module GraphProtocol
 
             queries(@instance, range_start: @offset, limit: @limit).each_with_index do |query,index|
               
-              sleep_until_ready(query, @instance.sleep_enabled, @instance.start_time) do |offset|
+              sleep_until_ready(query, @instance.sleep_enabled, @instance.start_time, @instance.speed_factor) do |offset|
                 break if cancelled?
               end unless index == 0
 

--- a/lib/graph_protocol/util/qlog/request_processor.rb
+++ b/lib/graph_protocol/util/qlog/request_processor.rb
@@ -17,27 +17,25 @@ module GraphProtocol
 
         def execute
 
-          Async do |task|
+          Async do
             internet = Async::HTTP::Internet.instance
             barrier = Async::Barrier.new
 
             queries(@instance, range_start: @offset, limit: @limit).each_with_index do |query,index|
-              
+
               sleep_until_ready(query, @instance.sleep_enabled, @instance.start_time, @instance.speed_factor) do |offset|
                 break if cancelled?
               end unless index == 0
 
               barrier.async do
-                task.with_timeout(30) do
-                  result = internet.post(*build_request(query))
-                  # puts result.read
-                  #unless result.success?
-                  #  puts "Failed query: #{query[:query_id]}"
-                  #  puts "#{result.inspect}"
-                  #end
-                  #
-                  result.close
-                end
+                result = internet.post(*build_request(query))
+                # puts result.read
+                #unless result.success?
+                #  puts "Failed query: #{query[:query_id]}"
+                #  puts "#{result.inspect}"
+                #end
+                #
+                result.close unless result.nil?
               end
 
               break if cancelled?

--- a/lib/graph_protocol/util/qlog/test_master.rb
+++ b/lib/graph_protocol/util/qlog/test_master.rb
@@ -15,7 +15,7 @@ module GraphProtocol
             size = queries(test_instance).count
             limit = test_instance.chunk_size || size
             offset = 0
-            test_instance.start_time = current_time 
+            test_instance.set_start_time current_time
 
             while size > offset
               return if cancelled?(test_instance)
@@ -36,7 +36,7 @@ module GraphProtocol
               offset += limit
 
               if test_instance.loop? and offset >= size
-                test_instance.start_time = current_time
+                test_instance.set_start_time current_time
                 offset = 0
               end
 

--- a/lib/graph_protocol/util/qlog/test_master.rb
+++ b/lib/graph_protocol/util/qlog/test_master.rb
@@ -43,7 +43,7 @@ module GraphProtocol
             end
 
             sleep_until_workers_finish(test_instance)
-          
+
             test_instance.set_status :finished
           rescue SignalException
             cancel!


### PR DESCRIPTION
- Switch to using jmalloc for memory allocations, as it seems like ruby is not very good at garbage collection after sidekiq jobs have finished
- Improved async request firing through a cleaner logic. Think this makes more sense now that we have a test master job
- Test master jobs run on the manager node which by design should be beefier / more stable and less pron to memory issues
- speed_factor is now properly calculated
- chunk_size default has been lowered to 100 (vs previous 1000)