### PR TITLE
Switch to Typhoeus http client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.0.0"
 
 gem 'activerecord-copy'
 gem 'sidekiq'
+gem 'typhoeus'
 gem 'async-http'
 gem 'thread-local'
 gem 'aws-sdk-s3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.11.0)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
+    ffi (1.15.5)
     fiber-local (1.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -209,6 +212,8 @@ GEM
     timeout (0.3.0)
     timers (4.3.4)
     traces (0.7.0)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.5)
@@ -233,6 +238,7 @@ DEPENDENCIES
   rails (~> 7.0.3, >= 7.0.3.1)
   sidekiq
   thread-local
+  typhoeus
   tzinfo-data
   zlib
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ module GraphProtocolQts
     config.eager_load_paths << Rails.root.join('lib')
     config.load_defaults 7.0
     config.active_job.queue_adapter = :sidekiq
-    config.log_level = :debug
+    config.log_level = :warn
     config.log_tags = [:subdomain, :uuid]
     config.logger    = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,12 @@
+require 'sidekiq/web'
+
+Sidekiq::Web.use ActionDispatch::Cookies
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: "_interslice_session"
+
 Rails.application.routes.draw do
+
+  mount Sidekiq::Web => '/sidekiq'
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
async-http has proven to be quite unstable, so we are switching to the Typhoeus http client library. 

I've also decreased default log level to avoid filling disk space with debug logs from the client, and enabled sidekiq web interface for tracking jobs (can be accessed via /sidekiq endpoint of the app)